### PR TITLE
Various noise improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ From a usage perspective, using positive alpha will tend to create a colorful ef
 
 Noise from the `SonarCustomNoise` node and `SonarPowerNoise` can be freely mixed.
 
+### `KRestartSamplerCustomNoise`
+
+If you have a recent enough version of [ComfyUI_restart_sampling](https://github.com/ssitu/ComfyUI_restart_sampling/)
+installed, you'll also get the `KRestartSamplerCustomNoise` node which is exactly the same as `KRestartSamplerCustom`
+except for adding an optional custom noise input.
+See the restart sampling repo for more information: https://github.com/ssitu/ComfyUI_restart_sampling
+
 ## Sonar Sampler Parameters
 
 Very abbreviated section. The init type can make a big difference. If you use `RANDOM` you can get away with setting `direction` to high values (like up to `2.25` or so) and absurdly low values (like `-30.0`). It's also possible to set `momentum` and `momentum_hist` to negative values, although whether it's a good idea...

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ If you want to create noise for initial sampling, connect model and sigmas to th
 
 can be used to override configuration settings for other samplers, including the noise type. For example, you could force `euler_ancestral` to use a different noise type. It's also possible to override other settings like `s_noise`, etc. *Note*: The wrapper inspects the sampling function's arguments to see what it supports, so you should connect the sampler directly to this rather than having other nodes (like a different sampler wrapper) in between.
 
-**Note**: If you are using this with Sonar samplers, make sure you set the noise type in the sampler to `gaussian` as the Sonar samplers only allow overriding noise types in that case.
-
 ### `SonarCustomNoise`
 
 See the [Noise](#noise) section below for information on noise types.
@@ -146,9 +144,9 @@ I also have some other ComfyUI nodes here: https://github.com/blepping/ComfyUI-b
 
 Original Sonar Sampler implementation (for A1111): https://github.com/Kahsolt/stable-diffusion-webui-sonar
 
-My version basically just rips off this Sonar sampler implementation for Diffusers: https://github.com/alexblattner/modified-euler-samplers-for-sonar-diffusers/
+My version was initially based on this Sonar sampler implementation for Diffusers: https://github.com/alexblattner/modified-euler-samplers-for-sonar-diffusers/
 
-Noise generation functions copied from https://github.com/Clybius/ComfyUI-Extra-Samplers with only minor modifications. I may have broken some of them in the process _or_ they may not have been suitable for use and I took them anyway. If they don't work it is not a reflection on the original source.
+Many noise generation functions copied from https://github.com/Clybius/ComfyUI-Extra-Samplers with only minor modifications. I may have broken some of them in the process _or_ they may not have been suitable for use and I took them anyway. If they don't work it is not a reflection on the original source.
 
 `SonarPowerNoise` contributed by [elias-gaeros](https://github.com/elias-gaeros/). Thanks!
 

--- a/__init__.py
+++ b/__init__.py
@@ -15,4 +15,7 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {}
 
+if hasattr(nodes, "KRestartSamplerCustomNoise"):
+    NODE_CLASS_MAPPINGS["KRestartSamplerCustomNoise"] = nodes.KRestartSamplerCustomNoise
+
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/changelog.md
+++ b/changelog.md
@@ -2,13 +2,15 @@
 
 Note, only relatively significant changes to user-visible functionality will be included here. Most recent changes at the top.
 
-## 20240325
+## 20240327
 
 * Fixed issue when using Sonar samplers in normal sampling nodes/via stuff like `KSamplerSelect`.
 * Add `pyramid` (non-high-res) noise type.
 * Allow selecting `brownian` noise in custom noise nodes (but it won't work with `NoisyLatentLike`).
 * Use `brownian` as the default noise type for `SamplerSonarDPMPP`.
 * Make overriding the selected noise type in Sonar samplers a warning instead of a hard error.
+* Improve noise scaling (may change seeds).
+* Add `KRestartSamplerCustomNoise` if the user has a recent enough version of ComfyUI_restart_sampling installed.
 
 ## 20240320
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 Note, only relatively significant changes to user-visible functionality will be included here. Most recent changes at the top.
 
+## 20240325
+
+* Fixed issue when using Sonar samplers in normal sampling nodes/via stuff like `KSamplerSelect`.
+* Add `pyramid` (non-high-res) noise type.
+* Allow selecting `brownian` noise in custom noise nodes (but it won't work with `NoisyLatentLike`).
+* Use `brownian` as the default noise type for `SamplerSonarDPMPP`.
+* Make overriding the selected noise type in Sonar samplers a warning instead of a hard error.
+
 ## 20240320
 
 * `NoisyLatentLike` node improved to allow calculating strength with sigmas and injecting noise itself.

--- a/py/nodes.py
+++ b/py/nodes.py
@@ -8,6 +8,7 @@ import torch
 from comfy import samplers
 
 from . import noise
+from .noise import NoiseType
 from .sonar import (
     GuidanceConfig,
     GuidanceType,
@@ -24,13 +25,7 @@ class NoisyLatentLikeNode:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "noise_type": (
-                    tuple(
-                        t.name.lower()
-                        for t in noise.NoiseType
-                        if t is not noise.NoiseType.BROWNIAN
-                    ),
-                ),
+                "noise_type": (tuple(NoiseType.get_names(skip=(NoiseType.BROWNIAN,))),),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFFFFFFFFFFFF}),
                 "latent": ("LATENT",),
                 "multiplier": ("FLOAT", {"default": 1.0}),
@@ -83,7 +78,7 @@ class NoisyLatentLikeNode:
             ns = custom_noise_opt.make_noise_sampler(latent_samples)
         else:
             ns = noise.get_noise_sampler(
-                noise.NoiseType[noise_type.upper()],
+                NoiseType[noise_type.upper()],
                 latent_samples,
                 None,
                 None,
@@ -164,13 +159,7 @@ class SonarCustomNoiseNode(SonarCustomNoiseNodeBase):
     def INPUT_TYPES(cls):
         result = super().INPUT_TYPES()
         result["required"] |= {
-            "noise_type": (
-                tuple(
-                    t.name.lower()
-                    for t in noise.NoiseType
-                    if t is not noise.NoiseType.BROWNIAN
-                ),
-            ),
+            "noise_type": (tuple(NoiseType.get_names()),),
         }
         return result
 
@@ -261,11 +250,7 @@ class SamplerNodeSonarBase:
                     },
                 ),
                 "rand_init_noise_type": (
-                    tuple(
-                        t.name.lower()
-                        for t in noise.NoiseType
-                        if t is not noise.NoiseType.BROWNIAN
-                    ),
+                    tuple(NoiseType.get_names(skip=(NoiseType.BROWNIAN,))),
                 ),
             },
             "optional": {
@@ -317,7 +302,7 @@ class SamplerNodeSonarEuler(SamplerNodeSonarBase):
             init=HistoryType[momentum_init.upper()],
             momentum_hist=momentum_hist,
             direction=direction,
-            rand_init_noise_type=noise.NoiseType[rand_init_noise_type.upper()],
+            rand_init_noise_type=NoiseType[rand_init_noise_type.upper()],
             guidance=guidance_cfg_opt,
         )
         return (
@@ -347,7 +332,7 @@ class SamplerNodeSonarEulerAncestral(SamplerNodeSonarEuler):
                         "round": False,
                     },
                 ),
-                "noise_type": (tuple(t.name.lower() for t in noise.NoiseType),),
+                "noise_type": (tuple(NoiseType.get_names()),),
             },
         )
         result["optional"].update(
@@ -375,8 +360,8 @@ class SamplerNodeSonarEulerAncestral(SamplerNodeSonarEuler):
             init=HistoryType[momentum_init.upper()],
             momentum_hist=momentum_hist,
             direction=direction,
-            rand_init_noise_type=noise.NoiseType[rand_init_noise_type.upper()],
-            noise_type=noise.NoiseType[noise_type.upper()],
+            rand_init_noise_type=NoiseType[rand_init_noise_type.upper()],
+            noise_type=NoiseType[noise_type.upper()],
             custom_noise=custom_noise_opt.clone() if custom_noise_opt else None,
             guidance=guidance_cfg_opt,
         )
@@ -408,7 +393,7 @@ class SamplerNodeSonarDPMPPSDE(SamplerNodeSonarEuler):
                         "round": False,
                     },
                 ),
-                "noise_type": (tuple(t.name.lower() for t in noise.NoiseType),),
+                "noise_type": (tuple(NoiseType.get_names(default=NoiseType.BROWNIAN)),),
             },
         )
         result["optional"].update(
@@ -436,8 +421,8 @@ class SamplerNodeSonarDPMPPSDE(SamplerNodeSonarEuler):
             init=HistoryType[momentum_init.upper()],
             momentum_hist=momentum_hist,
             direction=direction,
-            rand_init_noise_type=noise.NoiseType[rand_init_noise_type.upper()],
-            noise_type=noise.NoiseType[noise_type.upper()],
+            rand_init_noise_type=NoiseType[rand_init_noise_type.upper()],
+            noise_type=NoiseType[noise_type.upper()],
             custom_noise=custom_noise_opt.clone() if custom_noise_opt else None,
             guidance=guidance_cfg_opt,
         )
@@ -497,7 +482,7 @@ class SamplerNodeConfigOverride:
                 "sde_solver": (("midpoint", "heun"),),
             },
             "optional": {
-                "noise_type": (tuple(t.name.lower() for t in noise.NoiseType),),
+                "noise_type": (tuple(NoiseType.get_names()),),
                 "custom_noise_opt": ("SONAR_CUSTOM_NOISE",),
             },
         }
@@ -525,7 +510,7 @@ class SamplerNodeConfigOverride:
                 | {
                     "override_sampler_cfg": {
                         "sampler": sampler,
-                        "noise_type": noise.NoiseType[noise_type.upper()]
+                        "noise_type": NoiseType[noise_type.upper()]
                         if noise_type is not None
                         else None,
                         "custom_noise": custom_noise_opt,

--- a/py/powernoise.py
+++ b/py/powernoise.py
@@ -314,7 +314,8 @@ class SonarPowerNoiseNode(SonarCustomNoiseNodeBase):
 
         output_dir = folder_paths.get_temp_directory()
         prefix_append = "sonar_temp_" + "".join(
-            random.choice("abcdefghijklmnopqrstupvxyz") for x in range(5)  # noqa: S311
+            random.choice("abcdefghijklmnopqrstupvxyz")  # noqa: S311
+            for x in range(5)
         )
         full_output_folder, filename, counter, subfolder, _ = (
             folder_paths.get_save_image_path(prefix_append, output_dir)


### PR DESCRIPTION
* Fixed issue when using Sonar samplers in normal sampling nodes/via stuff like `KSamplerSelect`.
* Add `pyramid` (non-high-res) noise type.
* Allow selecting `brownian` noise in custom noise nodes (but it won't work with `NoisyLatentLike`).
* Use `brownian` as the default noise type for `SamplerSonarDPMPP`.
* Make overriding the selected noise type in Sonar samplers a warning instead of a hard error.
* Improve noise scaling (may change seeds).
* Add `KRestartSamplerCustomNoise` if the user has a recent enough version of ComfyUI_restart_sampling installed.